### PR TITLE
Update imgui dependency 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 imgui = "0.1.0"
-imgui-opengl-renderer = "0.5.0"
+imgui-opengl-renderer = "0.6.0"
 glfw = "0.31.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-imgui = "0.1.0"
 imgui-opengl-renderer = "0.6.0"
+imgui = "0.2.1"
 glfw = "0.31.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This essentially merges pull request #17 and #18, but the changes must be done simultaneously, as the previous version of `imgui-opengl-renderer` depends on `imgui 0.1.0` as well.